### PR TITLE
RF: alternative way to enable neurodebian on recent debian/ubuntus

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 
 # Enable NeuroDebian repository (if needed)
 RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive NEURODEBIAN_ENABLE=yes NEURODEBIAN_MIRROR=origin \
+    && DEBIAN_FRONTEND=noninteractive NEURODEBIAN_ENABLE=yes NEURODEBIAN_MIRROR=origin NEURODEBIAN_FLAVOR=full \
        apt-get install -y neurodebian
 
 # Run apt-get calls

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:16.04
 
+# Enable NeuroDebian repository (if needed)
 RUN apt-get update \
-    && apt-get install -y wget
-RUN wget -O /etc/apt/sources.list.d/neurodebian.sources.list http://neuro.debian.net/lists/xenial.us-ca.full
-RUN apt-key adv --recv-keys --keyserver hkp://pgp.mit.edu:80 0xA5D32F012649A5A9
+    && DEBIAN_FRONTEND=noninteractive NEURODEBIAN_ENABLE=yes NEURODEBIAN_MIRROR=origin \
+       apt-get install -y neurodebian
 
 # Run apt-get calls
 RUN apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM ubuntu:16.04
 
 # Enable NeuroDebian repository (if needed)
 RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive NEURODEBIAN_ENABLE=yes NEURODEBIAN_MIRROR=origin NEURODEBIAN_FLAVOR=full \
+    && DEBIAN_FRONTEND=noninteractive \
+       NEURODEBIAN_ENABLE=yes NEURODEBIAN_MIRROR=origin NEURODEBIAN_FLAVOR=full NEURODEBIAN_UPDATE=0 \
        apt-get install -y neurodebian
 
 # Run apt-get calls


### PR DESCRIPTION
Should work for Debian >= stretch, Ubuntu >= 15.10

Allows to avoid hardcoding release name etc

If generating dockers for local use, remove `NEURODEBIAN_MIRROR=origin` so it would then point to closest mirror
