### PR TITLE
Updated task descriptor according to what was published on Zenodo

### DIFF
--- a/boutiques/bids-app-example.json
+++ b/boutiques/bids-app-example.json
@@ -1,10 +1,12 @@
 {
+    "author": "chrisfilo and others",
     "command-line": "mkdir -p OUTPUT_DIR; /run.py BIDS_DIR OUTPUT_DIR ANALYSIS_LEVEL PARTICIPANT_LABEL SESSION_LABEL",
     "container-image": {
         "image": "bids/example",
         "type": "docker"
     },
     "description": "See https://github.com/BIDS-Apps/example",
+    "descriptor-url": "https://github.com/BIDS-Apps/example/blob/master/boutiques/bids-app-example.json", 
     "groups": [
         {
             "description": "For a participants analysis, an output directory name must be specified. For a group analysis, a directory containing the output of participant-level analyses must be selected. ",
@@ -148,7 +150,7 @@
         "title": "example.invocationSchema",
         "type": "object"
     },
-    "name": "example",
+    "name": "BIDS app example",
     "output-files": [
         {
             "description": "The directory where the output files should be stored. If you are running a group level analysis, this folder should be prepopulated with the results of the participant level analysis.",
@@ -159,5 +161,11 @@
         }
     ],
     "schema-version": "0.5",
+    "tags": {
+        "domain": [
+            "neuroinformatics", 
+            "testing"
+        ]
+    },
     "tool-version": "dev"
 }


### PR DESCRIPTION
Published the following descriptor to Zenodo as per boutiques/boutiques#174:
* https://zenodo.org/record/1451001

Added to the descriptor:
* Author (used the one from https://brainhack101.github.io/neurolinks/)
* Tags
* Descriptor URL

Changed the name from "example" to "BIDS app example"